### PR TITLE
Add GitHub Skills activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -33,6 +33,12 @@ activities = {
         "max_participants": 20,
         "participants": ["emma@mergington.edu", "sophia@mergington.edu"]
     },
+    "GitHub Skills": {
+        "description": "Practical Git and GitHub skills: collaboration, PR workflow, and basic Git operations.",
+        "schedule": "TBD — sessions will be announced",
+        "max_participants": 25,
+        "participants": []
+    },
     "Gym Class": {
         "description": "Physical education and sports activities",
         "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",


### PR DESCRIPTION
Add a small in-memory activity entry for "GitHub Skills" so it appears in the UI and API. This is a low-risk quick fix to satisfy issue #6 (Missing Activity: GitHub Skills).

- Adds activity entry in `src/app.py` with description, schedule TBD, max_participants 25.
- Does not change storage layer; this is a minimal PoC.

If you'd prefer activities be moved to `activities.json` instead, I can open a follow-up PR to refactor into a data file.